### PR TITLE
added functionality to not be able to delete future training programs

### DIFF
--- a/bangazon-api/Gemfile
+++ b/bangazon-api/Gemfile
@@ -30,6 +30,7 @@ gem 'faker', '~> 1.7', '>= 1.7.2'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry'
 end
 
 group :development do

--- a/bangazon-api/Gemfile.lock
+++ b/bangazon-api/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     arel (8.0.0)
     builder (3.2.3)
     byebug (9.1.0)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.2)
     erubi (1.7.0)
@@ -69,6 +70,9 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    pry (0.11.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     puma (3.10.0)
     rack (2.0.3)
     rack-test (0.7.0)
@@ -129,6 +133,7 @@ DEPENDENCIES
   byebug
   faker (~> 1.7, >= 1.7.2)
   listen (>= 3.0.5, < 3.2)
+  pry
   puma (~> 3.7)
   rails (~> 5.1.4)
   spring

--- a/bangazon-api/app/controllers/training_programs_controller.rb
+++ b/bangazon-api/app/controllers/training_programs_controller.rb
@@ -1,3 +1,5 @@
+# require 'pry'
+
 class TrainingProgramsController < ApplicationController
   before_action :set_training_program, only: [:show, :update, :destroy]
 
@@ -35,7 +37,11 @@ class TrainingProgramsController < ApplicationController
 
   # DELETE /training_programs/1
   def destroy
-    @training_program.destroy
+    if @training_program.start_date <= DateTime.now.to_date
+      @training_program.destroy
+    else
+      render html: "<script>alert('Program must be in the past to delete.')</script>"
+    end
   end
 
   private


### PR DESCRIPTION
## Description - why are you making the pull request?
Updating the group on the newly added functionality (added logic to not allow deletion of future training programs).

## What tickets is this in response to (include link)?
This is related to ticket #9.

## What files did you touch to create the PR?
Mainly training_programs_controller.rb
Also installed Pry to allow debugging.

## Related PRs (if applicable)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
1. Go to Postman and make a 'delete' call to a specific training program.
    - localhost:3000/training_programs/{training program ID goes here}
2. Depending on the start date of the specific program you've deleted, you'll either be allowed to delete or will get a message saying that you aren't able to delete future programs. 
```
