### PR TITLE
CORS functionality is added to only allow Bangazonian access

### DIFF
--- a/bangazon-api/Gemfile
+++ b/bangazon-api/Gemfile
@@ -29,7 +29,7 @@ gem 'faker', '~> 1.7', '>= 1.7.2'
 # gem 'capistrano-rails', group: :development
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors', '>= 1.0.2'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/bangazon-api/Gemfile.lock
+++ b/bangazon-api/Gemfile.lock
@@ -71,11 +71,14 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    nokogiri (1.8.1-x64-mingw32)
+      mini_portile2 (~> 2.3.0)
     pry (0.11.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     puma (3.10.0)
     rack (2.0.3)
+    rack-cors (1.0.2)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rails (5.1.4)
@@ -140,6 +143,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pry
   puma (~> 3.7)
+  rack-cors (>= 1.0.2)
   rails (~> 5.1.4)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/bangazon-api/config.ru
+++ b/bangazon-api/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'
-
+	
 run Rails.application

--- a/bangazon-api/config/application.rb
+++ b/bangazon-api/config/application.rb
@@ -21,6 +21,17 @@ module BangazonApi
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins 'www.bangazon.com:8080'
+        resource '*', :headers => :any, :methods => [:get, :post, :options]
+      end
+    end
+
+
+
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/test-api-cors/index.html
+++ b/test-api-cors/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Testing CORS</title>
+</head>
+<body>
+	<button id="test" type="button">Test</button>
+	
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+	<script type="text/javascript" src="main.js"></script>
+</body>
+</html>

--- a/test-api-cors/main.js
+++ b/test-api-cors/main.js
@@ -1,0 +1,7 @@
+console.log ("main.js working");
+
+$("#test").click(function(){
+    $.ajax({url: "http://localhost:3000/orders", success: function(result){
+        console.log ("RESULTS HERE", result);
+    }});
+});


### PR DESCRIPTION
## Description - why are you making the pull request?
This PR is addressing the need to restrict API usage for non-Bangazonian users

## What tickets is this in response to (include link)?
#12 

## What files did you touch to create the PR?
	modified:   bangazon-api/Gemfile
	modified:   bangazon-api/Gemfile.lock
	modified:   bangazon-api/config.ru
	modified:   bangazon-api/config/application.rb
	new file:   test-api-cors/index.html
	new file:   test-api-cors/main.js

## Related PRs (if applicable)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Gem install ```rack-cors``` version 1.0.2
2. Make a new alias for your local server, to be ```www.bangazon.com```
    * In your terminal type ```sudo sublime etc/hosts```
    * Copy/paste your ``` 127.0.0.1	localhost ``` line, then change localhost to www.bangazon.com
    * Save
3. Open the files within the ```test-api-cors``` folder.
4. Run the ```hs -o``` command in your terminal to start your local server, then click the Test button and check your terminal.
    * You should see a 'rejected' CORS alert.
5. Now change the url to www.bangazon.com:8080. Click the Test button again.
    * You should now see a successful return of orders from the API.

